### PR TITLE
Erhöhung des Grundbeitrages auf 30€ um den neuen Raum ab eintreten de…

### DIFF
--- a/satzung/beitragsordnung.tex
+++ b/satzung/beitragsordnung.tex
@@ -16,7 +16,7 @@
 \end{titlepage}
 \section{Festlegen der Höhe des Mitgliedsbeitrages}
 Mitglieder und Fördermitglieder haben einen Mitgliedsbeitrag von monatlich
-20 Euro zu entrichten. Zudem ist ein erhöter Beitragssatz von 30 Euro bzw. 40 Euro auf freiwilliger Basis des Mitglieds möglich.
+30 Euro zu entrichten. Zudem ist ein erhöter Beitragssatz von 35 Euro bzw. 40 Euro auf freiwilliger Basis des Mitglieds möglich.
 \section{Ermäßigung des Beitrages}
 Eine Ermäßigung des Mitgliedsbeitrages ist grundsätzlich möglich, Höhe und
 Dauer der Ermäßigung liegen im Ermessen des Vorstandes. Bei begründetem


### PR DESCRIPTION
…r Änderung sicher finanzieren zu können. Hier müssen wir keine neuen Mitglieder gewinnen, Rücklagen werden nicht angezapft.
